### PR TITLE
Abstract model functionality into a separate nn.Module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .DS_Store
+__pycache__/

--- a/model/ability_embedding.py
+++ b/model/ability_embedding.py
@@ -11,11 +11,9 @@ ABILITY_NAME_TO_NUM = dict(zip(ability_df['name'], ability_df['num']))
 # range from 0 to 305 as some are missing. Therefore, vocab_size will be slightly higher than actual number
 # of possible abilities to allow lookup without out of index error in the Embedding.
 VOCAB_SIZE = max(ABILITY_NAME_TO_NUM.values()) + 1
-EMBEDDING_DIM = 5
-
 
 class AbilityEmbedding(nn.Module):
-    def __init__(self, vocab_size=VOCAB_SIZE, embedding_dim=EMBEDDING_DIM):
+    def __init__(self, embedding_dim, vocab_size=VOCAB_SIZE):
         super().__init__()
         self.ability_embed = nn.Embedding(vocab_size, embedding_dim)
 

--- a/model/custom_pokemon_model.py
+++ b/model/custom_pokemon_model.py
@@ -1,0 +1,58 @@
+from model.ability_embedding import AbilityEmbedding
+from model.move_embedding import MoveEmbedding
+import torch
+import torch.nn as nn
+
+EMBEDDING_DIM = 5
+HIDDEN_DIM = 64
+
+class CustomPokemonModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.ability_embedding = AbilityEmbedding(embedding_dim=EMBEDDING_DIM)
+        self.move_embedding = MoveEmbedding(embedding_dim=EMBEDDING_DIM)
+
+        self.numerical_fc = nn.Linear(7 * 12, EMBEDDING_DIM)  # 7 stats for each pokemon on both teams
+
+        self.hidden_layer = nn.Sequential(
+            nn.Linear(EMBEDDING_DIM * (12 + 48 + 1), HIDDEN_DIM),
+            nn.ReLU(),
+            nn.Linear(HIDDEN_DIM, EMBEDDING_DIM)
+        )
+
+        self.action_fc = nn.Linear(EMBEDDING_DIM, 9)
+    
+    def forward(self, team, opponent_team):
+        abilities = [p.ability for p in team.pokemon] + [p.ability for p in opponent_team.pokemon]
+
+        moves = []
+        numerical_data = []
+
+        for p in team.pokemon:
+            moves += p.moves
+            numerical_data += p.stats
+            numerical_data.append(p.current_hp)
+
+        for p in opponent_team.pokemon:
+            moves += p.moves
+            numerical_data += p.stats
+            numerical_data.append(p.current_hp)
+
+        ability_embedding_output = torch.stack([self.ability_embedding(ability) for ability in abilities])
+        # 12 total abilities, 1 per pokemon
+        ability_embedding_output = ability_embedding_output.view(-1, 12 * EMBEDDING_DIM)
+
+        move_embedding_output = torch.stack([self.move_embedding(move) for move in moves])
+        # 12 pokemon * 4 moves each
+        move_embedding_output = move_embedding_output.view(-1, 48 * EMBEDDING_DIM)
+
+        numerical_fc_output = self.numerical_fc(torch.FloatTensor(numerical_data)).view(-1, EMBEDDING_DIM)
+
+        combined_input = torch.cat([ability_embedding_output, move_embedding_output, numerical_fc_output], dim=-1)
+        processed_features = self.hidden_layer(combined_input)
+
+        action_logits = self.action_fc(processed_features)
+        action_probs = nn.Softmax(dim=-1)(action_logits)
+
+        return action_probs

--- a/model/move_embedding.py
+++ b/model/move_embedding.py
@@ -11,11 +11,9 @@ MOVE_NAME_TO_NUM = dict(zip(moves_df['name'], moves_df['num']))
 # range from 0 to 900 as some are missing. Therefore, vocab_size will be slightly higher than actual number
 # of possible moves to allow lookup without out of index error in the Embedding.
 VOCAB_SIZE = max(MOVE_NAME_TO_NUM.values()) + 1
-EMBEDDING_DIM = 5
-
 
 class MoveEmbedding(nn.Module):
-    def __init__(self, vocab_size=VOCAB_SIZE, embedding_dim=EMBEDDING_DIM):
+    def __init__(self, embedding_dim, vocab_size=VOCAB_SIZE):
         super().__init__()
         self.move_embed = nn.Embedding(vocab_size, embedding_dim)
 

--- a/player_actor.py
+++ b/player_actor.py
@@ -1,6 +1,5 @@
-from battler import Pokemon, Team, Actor, Battler
+from battler import Team, Actor
 import random
-from model.model_actor import ModelActor
 
 possible_actions = [f"move {i}" for i in range(1, 5)] + [f"switch {i}" for i in range(2, 7)]
 
@@ -23,22 +22,3 @@ class RandomActor(Actor):
 
     def pick_move(self, knowledge) -> str:
         return random.choice(possible_actions)
-
-
-score = {'BOT_1': 0, 'BOT_2': 0}
-
-for i in range(100):
-    actor1 = ModelActor(None)
-    actor2 = RandomActor(None)
-
-    battler = Battler(actor1, actor2)
-
-    iteration = 0
-    while battler.current_state != 'end':
-        battler.make_moves()
-        # print("iteration:", iteration, battler.current_state)
-        iteration += 1
-    score[battler.winner] += 1
-    print(f'Game {i} finished')
-
-print(score)

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,24 @@
+from battler import Battler
+from model.model_actor import ModelActor
+from player_actor import RandomActor
+
+def simulate_games(n=100):
+    score = {'BOT_1': 0, 'BOT_2': 0}
+
+    for i in range(n):
+        actor1 = ModelActor(None)
+        actor2 = RandomActor(None)
+
+        battler = Battler(actor1, actor2)
+
+        iteration = 0
+        while battler.current_state != 'end':
+            battler.make_moves()
+            # print("iteration:", iteration, battler.current_state)
+            iteration += 1
+        score[battler.winner] += 1
+        print(f'Game {i} finished')
+
+    print(score)
+
+simulate_games(10)


### PR DESCRIPTION
This refactor should allow training `Custom_Pokemon_Model` because if it is contained within Model_Actor, I found it difficult to extract learnable parameters from all the layers present within model architecture. 

Also created a utils.py file for testing + misc. stuff. I moved the simulation loop from player_actor into this new file. 