### PR TITLE
Implement REINFORCE algorithm for Policy Gradient RL

### DIFF
--- a/battler.py
+++ b/battler.py
@@ -40,6 +40,12 @@ class Team:
         self.name = json_val["side"]["name"]
         self.pokemon = [Pokemon(json_poke) for json_poke in json_val["side"]["pokemon"]]
 
+    def calculate_total_HP(self):
+        total_HP = 0
+        for p in self.pokemon:
+            total_HP += p.current_hp
+        return total_HP
+
     def print_short_info(self):
         self.pokemon[0].print_short_info()
         print(

--- a/model/custom_pokemon_model.py
+++ b/model/custom_pokemon_model.py
@@ -3,7 +3,7 @@ from model.move_embedding import MoveEmbedding
 import torch
 import torch.nn as nn
 
-EMBEDDING_DIM = 5
+EMBEDDING_DIM = 128
 HIDDEN_DIM = 64
 
 class CustomPokemonModel(nn.Module):

--- a/model/model_actor.py
+++ b/model/model_actor.py
@@ -8,6 +8,7 @@ class ModelActor(Actor):
 
         self.custom_pokemon_model = CustomPokemonModel()
         self.prev_probs = None
+        self.prev_probs_sorted = None
         self.errors = 0
 
     def pick_move(self, knowledge) -> str:
@@ -22,7 +23,7 @@ class ModelActor(Actor):
             self.errors += 1
             # using % 9 is a very hacky fix that needs to be removed.
             # self.errors should never exceed 8 if we handle the errors described above
-            choice = self.prev_probs[self.errors % 9]
+            choice = self.prev_probs_sorted[self.errors % 9]
 
             if choice < 4:
                 return f'move {choice + 1}'
@@ -42,7 +43,8 @@ class ModelActor(Actor):
         # prev_probs[0] is the highest prob choice
         choice = choices[0]
         # we store the entire distribution of probs in prev_probs, so that on error we can try again with the next best choice
-        self.prev_probs = choices
+        self.prev_probs_sorted = choices
+        self.prev_probs = action_probs
 
         if choice < 4:
             return f'move {choice + 1}'

--- a/trainer.py
+++ b/trainer.py
@@ -1,0 +1,97 @@
+from battler import Battler
+from model.model_actor import ModelActor
+from player_actor import RandomActor
+from utils import simulate_games
+import random
+import torch.optim as optim
+
+def train(model_actor, random_actor, gamma, epsilon, epsilon_decay, min_epsilon, num_episodes, optimizer):
+    score = {'BOT_1': 0, 'BOT_2': 0}
+    possible_actions = [f"move {i}" for i in range(1, 5)] + [f"switch {i}" for i in range(2, 7)]
+    
+    # Training Loop
+    for episode in range(num_episodes):
+        battler = Battler(model_actor, random_actor)
+        battler.make_moves()
+
+        while battler.current_state != 'end':
+            original_total_hp_actor_1 = battler.actor1.team.calculate_total_HP()
+            original_total_hp_actor_2 = battler.actor2.team.calculate_total_HP()
+            # print(battler.p1move)
+            # print(battler.p2move)
+
+            action_probs = model_actor.custom_pokemon_model.forward(battler.actor1.team, battler.actor2.team)
+            current_q_value = action_probs.max()
+            
+            # battler.make_moves()
+            if battler.p1move:
+                knowledge = {"field": None, "opponent": battler.actor2.team, "error": battler.error}
+                # Epsilon-greedy policy for exploration
+                # In the beginning, model actor is essentially picking random moves. Over time, it uses its learned
+                # strategy more and more as epsilon decays. 
+                if random.random() < epsilon:
+                    move = random.choice(possible_actions)
+                else:
+                    move = f">p1 {battler.actor1.pick_move(knowledge)}"
+                # print(move)
+                battler.send_command(move)
+                battler.p1move = False
+
+            if battler.p2move:
+                knowledge = {"field": None, "opponent": battler.actor1.team, "error": battler.error}
+                move = f">p2 {battler.actor2.pick_move(knowledge)}"
+                # print(move)
+                battler.send_command(move)
+                battler.p2move = False
+            
+            battler.receive_output()
+
+            # Calculate reward based on damage exchanged (considering full teams in case a switch move occurred)
+            damage_dealt = battler.actor2.team.calculate_total_HP() - original_total_hp_actor_2
+            damage_recieved = battler.actor1.team.calculate_total_HP() - original_total_hp_actor_1
+            reward = damage_dealt - damage_recieved
+            # print(reward)
+
+            next_probs = model_actor.custom_pokemon_model.forward(battler.actor1.team, battler.actor2.team)
+            # TODO: figure out better / more robust way to calculate Q value instead of relying on action probs only
+            target_q_value = reward + (gamma * next_probs.max().detach())
+            
+            # TODO: currently using MSE loss but we should probably refine this
+            loss = (current_q_value - target_q_value) ** 2
+
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+        
+        epsilon = max(min_epsilon, epsilon * epsilon_decay) # Decay epsilon
+        if episode % 10 == 0:
+            print(f"Episode {episode}, Epsilon {epsilon:.3f}")
+            print(f'Game {episode} finished')
+        
+        score[battler.winner] += 1
+
+    print("Score during traning: ")
+    print(score)
+    print(f"Win rate for BOT_1: {(score['BOT_1'] / num_episodes * 100):.2f}")
+    print(f"Win rate for BOT_2: {(score['BOT_2'] / num_episodes * 100):.2f}")
+
+############## Training ##############
+
+# Hyperparameters
+learning_rate = 0.001
+gamma = 0.99
+epsilon = 1.0
+epsilon_decay = 0.99
+min_epsilon = 0.01
+num_episodes = 100
+
+model_actor = ModelActor(None)
+random_actor = RandomActor(None)
+optimizer = optim.Adam(model_actor.custom_pokemon_model.parameters(), lr=learning_rate)
+
+train(model_actor, random_actor, gamma, epsilon, epsilon_decay, min_epsilon, num_episodes, optimizer)
+
+############## Validation ##############
+
+print("\nScore during validation: ")
+simulate_games(model_actor, random_actor, 100)

--- a/trainer.py
+++ b/trainer.py
@@ -22,7 +22,7 @@ def train(model_actor, random_actor, gamma, num_episodes, optimizer):
             prob_action = None # probability of action chosen by model in current game state
             reward = None # reward received after executing actions in current game state
 
-            original_total_hp_actor_1 = model_actor.team.calculate_total_HP()
+            original_total_hp_model_actor = model_actor.team.calculate_total_HP()
             original_total_hp_actor_2 = battler.actor2.team.calculate_total_HP()
             
             if battler.p1move:
@@ -58,8 +58,8 @@ def train(model_actor, random_actor, gamma, num_episodes, optimizer):
 
             # TODO: Improve reward heuristic
             # Calculate reward based on damage exchanged (considering full teams in case a switch move occurred)
-            damage_dealt = battler.actor2.team.calculate_total_HP() - original_total_hp_actor_2
-            damage_recieved = model_actor.team.calculate_total_HP() - original_total_hp_actor_1
+            damage_dealt = original_total_hp_actor_2 - battler.actor2.team.calculate_total_HP()
+            damage_recieved = original_total_hp_model_actor - model_actor.team.calculate_total_HP()
             reward = max(0.1, damage_dealt - damage_recieved)
             # print(reward)
             
@@ -124,6 +124,9 @@ num_episodes = 100
 model_actor = ModelActor(None)
 random_actor = RandomActor(None)
 optimizer = optim.Adam(model_actor.custom_pokemon_model.parameters(), lr=learning_rate)
+
+total_params = sum(p.numel() for p in model_actor.custom_pokemon_model.parameters() if p.requires_grad)
+print(f"Total trainable params in custom pokemon model: {total_params}")
 
 train(model_actor, random_actor, gamma, num_episodes, optimizer)
 

--- a/trainer.py
+++ b/trainer.py
@@ -2,43 +2,46 @@ from battler import Battler
 from model.model_actor import ModelActor
 from player_actor import RandomActor
 from utils import simulate_games
-import random
+import torch
 import torch.optim as optim
 
-def train(model_actor, random_actor, gamma, epsilon, epsilon_decay, min_epsilon, num_episodes, optimizer):
+def train(model_actor, random_actor, gamma, num_episodes, optimizer):
     score = {'BOT_1': 0, 'BOT_2': 0}
-    possible_actions = [f"move {i}" for i in range(1, 5)] + [f"switch {i}" for i in range(2, 7)]
     
+    ############## Implementing Policy Gradients as decribed below ##############
+    # https://towardsdatascience.com/reinforcement-learning-explained-visually-part-6-policy-gradients-step-by-step-f9f448e73754
+
     # Training Loop
     for episode in range(num_episodes):
         battler = Battler(model_actor, random_actor)
         battler.make_moves() # Initial game setup hack so p1move and p2move are not both False
 
-        avg_loss = 0
-        iterations = 0
+        gamma_factor = 1
+        total_discounted_reward = 0
+        training_samples = [] # store all game states and moves experienced by model in a single episode / battle
 
+        ############## PLAY AN ENTIRE EPISODE / BATTLE AND RECORD EACH INTERACTION ##############
         while battler.current_state != 'end':
-            original_total_hp_actor_1 = battler.actor1.team.calculate_total_HP()
-            original_total_hp_actor_2 = battler.actor2.team.calculate_total_HP()
+            model_team = None # model's team in current game state
+            opponent_team = None # opponent's team in current game state
+            model_move = None # action chosen by model in current game state
+            discounted_reward = None # reward received after executing actions in current game state
 
-            action_probs = model_actor.custom_pokemon_model.forward(battler.actor1.team, battler.actor2.team)
-            current_q_value = action_probs.max()
+            original_total_hp_actor_1 = model_actor.team.calculate_total_HP()
+            original_total_hp_actor_2 = battler.actor2.team.calculate_total_HP()
             
             if battler.p1move:
                 knowledge = {"field": None, "opponent": battler.actor2.team, "error": battler.error}
-                # Epsilon-greedy policy for exploration
-                # In the beginning, model actor is essentially picking random moves. Over time, it uses its learned
-                # strategy more and more as epsilon decays. 
-                if random.random() < epsilon:
-                    move = f">p1 {random.choice(possible_actions)}"
-                else:
-                    move = f">p1 {battler.actor1.pick_move(knowledge)}"
+                model_team = model_actor.team
+                model_move = model_actor.pick_move(knowledge)
+                move = f">p1 {model_move}"
                 # print(move)
                 battler.send_command(move)
                 battler.p1move = False
 
             if battler.p2move:
-                knowledge = {"field": None, "opponent": battler.actor1.team, "error": battler.error}
+                knowledge = {"field": None, "opponent": model_actor.team, "error": battler.error}
+                opponent_team = battler.actor2.team
                 move = f">p2 {battler.actor2.pick_move(knowledge)}"
                 # print(move)
                 battler.send_command(move)
@@ -48,28 +51,63 @@ def train(model_actor, random_actor, gamma, epsilon, epsilon_decay, min_epsilon,
 
             # Calculate reward based on damage exchanged (considering full teams in case a switch move occurred)
             damage_dealt = battler.actor2.team.calculate_total_HP() - original_total_hp_actor_2
-            damage_recieved = battler.actor1.team.calculate_total_HP() - original_total_hp_actor_1
-            reward = damage_dealt - damage_recieved
-            # print(reward)
+            damage_recieved = model_actor.team.calculate_total_HP() - original_total_hp_actor_1
+            discounted_reward = damage_dealt - damage_recieved
+            discounted_reward *= gamma_factor
 
-            next_probs = model_actor.custom_pokemon_model.forward(battler.actor1.team, battler.actor2.team)
-            # TODO: figure out better / more robust way to calculate Q value instead of relying on action probs only
-            target_q_value = reward + (gamma * next_probs.max().detach())
+            total_discounted_reward += discounted_reward
+            gamma_factor *= gamma
+            # print(discounted_reward)
             
-            # TODO: currently using MSE loss but we should probably refine this
-            loss = (current_q_value - target_q_value) ** 2
-            avg_loss += loss
-
-            optimizer.zero_grad()
-            loss.backward()
-            optimizer.step()
-
-            iterations += 1
+            # Save each sample of observed experience as training data
+            state = (model_team, opponent_team)
+            training_samples.append((state, model_move, discounted_reward))
         
-        epsilon = max(min_epsilon, epsilon * epsilon_decay) # Decay epsilon
+        ############## USE PREVIOUS BATTLE EXPERIENCES TO TUNE NETWORK WEIGHTS ##############
+        total_loss = 0
+        invalid_samples = 0
+
+        for sample in training_samples:
+            state, action, reward = sample
+            team, opponent = state
+            if (team is None or opponent is None or action is None):
+                invalid_samples += 1
+                total_discounted_reward -= reward
+                continue
+
+            model_actor.team = team
+            knowledge = {"field": None, "opponent": opponent, "error": None}
+            model_actor.pick_move(knowledge)
+
+            action_type, action_num = action.split(" ")
+            action_index = None
+            if (action_type == "move"):
+                action_index = int(action_num) - 1
+            else:
+                action_index = int(action_num) + 2
+
+            prob_action = model_actor.prev_probs[0][action_index]
+            if (prob_action > 0):
+                loss = -torch.log(prob_action) * total_discounted_reward
+            else: 
+                # prev_probs is nan during some runs causing prob_action to be 0 / nan
+                # a little debugging shows that model is probably updating weights in strange ways
+                # so we need to refine the back prop step.
+                print(model_actor.prev_probs)
+                loss = 0
+            total_loss += loss
+            total_discounted_reward -= reward
+
+        # The check below is done as sometimes: 
+        # (1) training samples are too few and all of them are invalid, OR
+        # (2) losses are 0 due to prev_probs being nan (see else block above)
+        if (total_loss != 0):
+            total_loss.backward()
+            optimizer.step()
+            optimizer.zero_grad()
+
         if episode % 10 == 0:
-            print(f"Episode {episode}, Epsilon {epsilon:.3f}")
-            print(f"Game {episode} finished with avg. loss of {avg_loss / iterations}")
+            print(f"Game {episode} finished with total loss = {total_loss}, % of invalid samples = {(invalid_samples / len(training_samples) * 100):.2f}")
         
         score[battler.winner] += 1
 
@@ -83,16 +121,13 @@ def train(model_actor, random_actor, gamma, epsilon, epsilon_decay, min_epsilon,
 # Hyperparameters
 learning_rate = 0.001
 gamma = 0.99
-epsilon = 1.0
-epsilon_decay = 0.99
-min_epsilon = 0.01
 num_episodes = 100
 
 model_actor = ModelActor(None)
 random_actor = RandomActor(None)
 optimizer = optim.Adam(model_actor.custom_pokemon_model.parameters(), lr=learning_rate)
 
-train(model_actor, random_actor, gamma, epsilon, epsilon_decay, min_epsilon, num_episodes, optimizer)
+train(model_actor, random_actor, gamma, num_episodes, optimizer)
 
 ############## Validation ##############
 

--- a/trainer.py
+++ b/trainer.py
@@ -30,7 +30,7 @@ def train(model_actor, random_actor, gamma, epsilon, epsilon_decay, min_epsilon,
                 # In the beginning, model actor is essentially picking random moves. Over time, it uses its learned
                 # strategy more and more as epsilon decays. 
                 if random.random() < epsilon:
-                    move = random.choice(possible_actions)
+                    move = f">p1 {random.choice(possible_actions)}"
                 else:
                     move = f">p1 {battler.actor1.pick_move(knowledge)}"
                 # print(move)

--- a/trainer.py
+++ b/trainer.py
@@ -70,6 +70,7 @@ def train(model_actor, random_actor, gamma, num_episodes, optimizer):
         for sample in training_samples:
             state, action, reward = sample
             team, opponent = state
+            # Can we somehow reduce # of invalid samples generated during battle? 
             if (team is None or opponent is None or action is None):
                 invalid_samples += 1
                 total_discounted_reward -= reward

--- a/utils.py
+++ b/utils.py
@@ -14,10 +14,11 @@ def simulate_games(actor1, actor2, n=100):
             # print("iteration:", iteration, battler.current_state)
             iteration += 1
         score[battler.winner] += 1
-        print(f'Game {i} finished')
+        if (i % 10 == 0):
+            print(f'Game {i} finished')
 
     print(score)
     print(f"Win rate for BOT_1: {(score['BOT_1'] / n * 100):.2f}")
     print(f"Win rate for BOT_2: {(score['BOT_2'] / n * 100):.2f}")
 
-# simulate_games(ModelActor(None), RandomActor(None), 10)
+# simulate_games(ModelActor(None), RandomActor(None), 100)

--- a/utils.py
+++ b/utils.py
@@ -2,13 +2,10 @@ from battler import Battler
 from model.model_actor import ModelActor
 from player_actor import RandomActor
 
-def simulate_games(n=100):
+def simulate_games(actor1, actor2, n=100):
     score = {'BOT_1': 0, 'BOT_2': 0}
 
     for i in range(n):
-        actor1 = ModelActor(None)
-        actor2 = RandomActor(None)
-
         battler = Battler(actor1, actor2)
 
         iteration = 0
@@ -20,5 +17,7 @@ def simulate_games(n=100):
         print(f'Game {i} finished')
 
     print(score)
+    print(f"Win rate for BOT_1: {(score['BOT_1'] / n * 100):.2f}")
+    print(f"Win rate for BOT_2: {(score['BOT_2'] / n * 100):.2f}")
 
-simulate_games(10)
+# simulate_games(ModelActor(None), RandomActor(None), 10)


### PR DESCRIPTION
EDIT: see comments below as well!

Main changes:
- Implement REINFORCE as described [here](https://towardsdatascience.com/reinforcement-learning-explained-visually-part-6-policy-gradients-step-by-step-f9f448e73754) and also [here](https://dilithjay.com/blog/reinforce-a-quick-introduction-with-code). The algorithm in general exhibits high variance and slow convergence. 
- Experimented with training and noticed 3 main issues / TODOs we need to address:
  - **Reward Heuristic:** Surprisingly, I was able to achieve a `>70%` win rate quite regularly over several runs when just using a fixed scalar value for the reward instead of damage dealt vs. received. Also tried max(0.1, damage_dealt - damage_recieved) to eliminate negative rewards / losses. 
  - **Well-formed Training Samples:** We need battle experiences such as state of both teams, chosen move by model etc. before updating weights in REINFORCE. However, during some moves, it seems only one player actually moves causing some of the state variables to be None and therefore not usable during loss calculation / weights update step.
  - **Total Discounted Returns:** I believe I implement this part correctly, although it would be nice if someone could cross-check as `dicounted_returns` directly impacts loss calculation and subsequent training. 

Other changes:
- Increase `EMBEDDING_DIM` to 128 as done in this [paper](https://ieee-cog.org/2019/papers/paper_175.pdf). 
- Add helper method to calculate total HP in battler.