### PR TITLE
Add mask for disabled moves, small changes to model and reward

### DIFF
--- a/battler.py
+++ b/battler.py
@@ -39,6 +39,14 @@ class Team:
         self.actor = json_val["side"]["id"]
         self.name = json_val["side"]["name"]
         self.pokemon = [Pokemon(json_poke) for json_poke in json_val["side"]["pokemon"]]
+        # If we are forced to switch or are currently waiting, all moves are inactive
+        if "forceSwitch" in json_val or "wait" in json_val:
+            print("force switch or wait")
+            self.disabled = [True] * 4
+        else:
+            # If a pokemon is trapped, Showdown returns the one move we are allowed to play and the disabled attribute is missing
+            # This is why the default value is being used as False (active move)
+            self.disabled = [move.get("disabled", False) for move in json_val["active"][0]["moves"]]
 
     def calculate_total_HP(self):
         total_HP = 0
@@ -109,6 +117,7 @@ class Battler:
         self.error = False
         while self.current_state != 'await':
             output = self.process.stdout.readline().strip().split('|')
+            # print(output)
             if self.current_state != 'end':
                 self.current_state = Battler.transitions[self.current_state][output[0]]
             else:

--- a/model/custom_pokemon_model.py
+++ b/model/custom_pokemon_model.py
@@ -5,6 +5,7 @@ import torch.nn as nn
 
 EMBEDDING_DIM = 128
 HIDDEN_DIM = 64
+LSTM_HIDDEN_DIM = 128
 
 
 class CustomPokemonModel(nn.Module):
@@ -16,15 +17,21 @@ class CustomPokemonModel(nn.Module):
 
         self.numerical_fc = nn.Linear(7 * 12, EMBEDDING_DIM)  # 7 stats for each pokemon on both teams
 
+        self.lstm = nn.LSTM(
+            input_size=EMBEDDING_DIM * (12 + 48 + 1),
+            hidden_size=LSTM_HIDDEN_DIM,
+            batch_first=True,
+        )
+
         self.hidden_layer = nn.Sequential(
-            nn.Linear(EMBEDDING_DIM * (12 + 48 + 1), HIDDEN_DIM),
+            nn.Linear(LSTM_HIDDEN_DIM, HIDDEN_DIM),
             nn.ReLU(),
             nn.Linear(HIDDEN_DIM, EMBEDDING_DIM)
         )
 
         self.action_fc = nn.Linear(EMBEDDING_DIM, 9)
 
-    def forward(self, team, opponent_team):
+    def forward(self, team, opponent_team, hidden_states=None):
         abilities = [p.ability for p in team.pokemon] + [p.ability for p in opponent_team.pokemon]
 
         moves = []
@@ -51,19 +58,30 @@ class CustomPokemonModel(nn.Module):
         numerical_fc_output = self.numerical_fc(torch.FloatTensor(numerical_data)).view(-1, EMBEDDING_DIM)
 
         combined_input = torch.cat([ability_embedding_output, move_embedding_output, numerical_fc_output], dim=-1)
-        processed_features = self.hidden_layer(combined_input)
+        combined_input = combined_input.unsqueeze(0)
+
+        if hidden_states is None:
+            h_0 = torch.zeros(1, combined_input.size(0), LSTM_HIDDEN_DIM)
+            c_0 = torch.zeros(1, combined_input.size(0), LSTM_HIDDEN_DIM)
+            hidden_states = (h_0, c_0)
+        else:
+            hidden_states = tuple(h.detach() for h in hidden_states)
+
+        lstm_output, hidden_states = self.lstm(combined_input, hidden_states)
+        lstm_output = lstm_output.squeeze(0)
+
+        processed_features = self.hidden_layer(lstm_output)
 
         action_logits = self.action_fc(processed_features)
         action_probs = nn.Softmax(dim=-1)(action_logits)
 
         mask = torch.FloatTensor(team.invalid_mask)
-        if mask.sum() > 0:
-            masked_action_probs = action_probs * mask
+        masked_action_probs = action_probs * mask
+        if masked_action_probs.sum() > 0:
             masked_action_probs = masked_action_probs / masked_action_probs.sum()
         else:
-            # TODO This seems to happen due to a weird case where we get a request but it's not active, it's "waiting"
-            # I'm thinking we need to handle this case in a better way and wait for the next request from showdown
             # print('all moves invalid')
-            return action_probs
+            action_probs = action_probs / action_probs.sum()
+            return action_probs, hidden_states
 
-        return masked_action_probs
+        return masked_action_probs, hidden_states

--- a/model/model_actor.py
+++ b/model/model_actor.py
@@ -10,6 +10,7 @@ class ModelActor(Actor):
         self.prev_probs = None
         self.prev_probs_sorted = None
         self.errors = 0
+        self.hidden_states = None
 
     def pick_move(self, knowledge) -> str:
         # knowledge['opponent'].print_short_info()
@@ -32,7 +33,8 @@ class ModelActor(Actor):
         # once we stop erroring we can reset the error index to 0
         self.errors = 0
 
-        action_probs = self.custom_pokemon_model.forward(self.team, knowledge['opponent'])
+        action_probs, self.hidden_states = self.custom_pokemon_model.forward(
+            self.team, knowledge['opponent'], self.hidden_states)
 
         # The output is 9 numbers which we're taking to represent the probability of choosing an action
         # indices 0-3 represent moves 1-4 of the active pokemon

--- a/trainer.py
+++ b/trainer.py
@@ -118,16 +118,19 @@ def train(model_actor, random_actor, gamma, num_episodes, optimizer):
 
             total_loss = total_loss + loss  # negative loss values are due to negative rewards
 
+        valid_samples = len(training_samples) - invalid_samples
+
         # This check is done as sometimes training samples are too few / invalid causing total_loss to be 0
         if (total_loss != 0 and not torch.isnan(total_loss)):
+            mean_loss = total_loss / valid_samples
             optimizer.zero_grad()
-            total_loss.backward()
+            mean_loss.backward()
             optimizer.step()
         else:
             print("not updating loss due to invalid loss")
 
         if episode % 10 == 0:
-            print(f"Game {episode} finished with total loss = {(total_loss):.2f}, % of invalid samples = {(invalid_samples / len(training_samples) * 100):.2f}")
+            print(f"Game {episode} finished with mean loss = {(mean_loss):.2f}, % of invalid samples = {(invalid_samples / len(training_samples) * 100):.2f}")
         score[battler.winner] += 1
 
     print("Score during traning: ")


### PR DESCRIPTION
Creates a mask within the team object that indicates which actions are valid for the given turn. This disallows the model from selecting invalid moves.

Also adjusts the reward function to include bonuses for winning battles or knocking out pokemon (the second of which may be less useful). But it also scales the weighting of damage (immediate) rewards against the weighting of winning (long term) rewards as the episodes progress.

The model also has a LSTM component now, which I hoped would help it begin to train more effectively. 

As of now these additions don't significantly impact WR when compared to the main branch, but they may be useful once we improve embeddings, increase model knowledge, etc.